### PR TITLE
fix(equation numbering): skip newlines after comments to prevent commenting out lines 

### DIFF
--- a/src/equation_number.ts
+++ b/src/equation_number.ts
@@ -210,20 +210,26 @@ export function insertTagInMathText(text: string, tagContent: string, lineByLine
     if (lineByLine) {
         const alignResult = text.match(/^\s*\\begin\{align\}([\s\S]*)\\end\{align\}\s*$/);
         if (alignResult) {
-            let taggedText = "";
+            // remove comments
+            let alignContent = alignResult[1]
+                .split('\n')
+                .map(line => {
+                    const commentMatch = line.match(/(?<!\\)\%/);
+                    return commentMatch?.index !== undefined
+                        ? line.substring(0, commentMatch.index)
+                        : line;
+                }).join('\n');
+            // add tags
             let index = 1;
-            for (const line of alignResult[1].split("\\\\")) {
-                if (line.trim()) {
-                    taggedText += line.contains("\\nonumber") ?
-                        line :
-                        line.trim() + `\\tag{${tagContent}-${index++}}`;
-                    taggedText += "\\\\";
-                }
-            }
-            return "\\begin{align}" + taggedText + "\\end{align}";
+            alignContent = alignContent.split("\\\\").map(alignLine => {
+                return (!alignLine.trim() || alignLine.contains("\\nonumber"))
+                    ? alignLine
+                    : (alignLine + `\\tag{${tagContent}-${index++}}`);
+            }).join("\\\\");
+            return "\\begin{align}" + alignContent + "\\end{align}";
         }
     }
-    return text.replace(/(?<!%)([\n\r])/g, ' ') + `\\tag{${tagContent}}`;
+    return text + `\\tag{${tagContent}}`;
 }
 
 

--- a/src/equation_number.ts
+++ b/src/equation_number.ts
@@ -223,7 +223,7 @@ export function insertTagInMathText(text: string, tagContent: string, lineByLine
             return "\\begin{align}" + taggedText + "\\end{align}";
         }
     }
-    return text.replace(/[\n\r]/g, ' ') + `\\tag{${tagContent}}`;
+    return text.replace(/(?<!%)([\n\r])/g, ' ') + `\\tag{${tagContent}}`;
 }
 
 


### PR DESCRIPTION
[screencast.webm](https://github.com/RyotaUshio/obsidian-math-booster/assets/118958751/f7d07337-d762-424e-9633-b57af3f982e1)

In latex '%' comments out the line, so removing all newlines in a math block breaks it. A simple fix is to just prepend negative lookbehinds to original regexp.
